### PR TITLE
Small fixes

### DIFF
--- a/src/api/repos/repositories.js
+++ b/src/api/repos/repositories.js
@@ -83,7 +83,7 @@ function createApi(api, opts = {}) {
      * @param {String} slug (name) of the repo.
      */
     get(username, repoSlug, callback) {
-      validateArgs('get', 2, arguments)
+      validateArgs('get', arguments, 2)
       const uri = buildUri(username, repoSlug)
       api.get(
         uri,

--- a/src/util/validator.js
+++ b/src/util/validator.js
@@ -19,7 +19,7 @@ function createArgValidator(methodName) {
 }
 
 function validateArgs(methodName, args, argsLength = 2) {
-  args = [].slice.call(args, 0, -1)
+  args = Array.prototype.slice.call(args, 0, -1)
   const argValidator = createArgValidator(methodName)
   if (args.length !== argsLength) {
     handleError(`${methodName}: Expected ${argsLength} arguments but received ${args.length}`)


### PR DESCRIPTION
I tried to used the lib, and had an error when doing things such as:

    const repositories = bitbucketApi.repositories.promised;
    repositories.get(user, slug)
      .then(data => { // do something });

The error I got was:

> get: Expected [object Arguments] arguments but received 0

It came from two things:
- The `validateArgs` function slices the `args` it receives. Apparently, doing it on an empty array doesn't work, but calling `Array.prototype.slice` does.
- When calling `validateArgs` from `repositories.get`, the order of `arguments` and the number of expected arguments was swapped.

So I felt free to submit this PR fixing both things. I had issues with running `npm test` though (`Unexpected token import`... meaning that sources were not `babel`ified when running tests?).