### PR TITLE
Set `getAccessToken` inside local scope

### DIFF
--- a/src/bitbucket.js
+++ b/src/bitbucket.js
@@ -15,7 +15,7 @@ const $api = require('./api')
  */
 
 async function createAuthenticatedAPI(opts = {}) {
-  getAccessToken = opts.getAccessToken
+  const getAccessToken = opts.getAccessToken
   if (!getAccessToken) {
     throw 'ERROR: Missing getAccessToken (function) option'
   }


### PR DESCRIPTION
`getAccessToken` is part of global scope. it's can be dangerous.

